### PR TITLE
Add useful attributes for the post code input

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -12,7 +12,7 @@ In 2015, <strong>most people</strong> voted for someone who <strong>didn't becom
 </p>
 
 <form class="postcode-search" action="/postcodes.php" method="POST">
-  <input type="text" class="postcode" name="postcode" placeholder="SW1A 0AA" />
+  <input type="text" spellcheck="false" autocorrect="off" maxlength="9" class="postcode" name="postcode" placeholder="SW1A 0AA" />
   <input type="submit" value="&#128269;" />
 </form>
 


### PR DESCRIPTION
it's not helpful to have postcode input spellchecked or autocorrected - so lets disable those.
Adding a maxlength can help prevent overloading the form with huge data by bots.