### PR TITLE
Re-word the top information box

### DIFF
--- a/dontsplittheremainvote/classify.py
+++ b/dontsplittheremainvote/classify.py
@@ -61,15 +61,6 @@ class _LeaveVictory(ClassifyResult):
             remain_can_win=False,
             alliance_helpful=False)
 
-class _AllianceNeeded(ClassifyResult):
-    def __new__(self, short1, short2, long1):
-        return super().__new__(self,
-            logo=f'alliance-victory-{short1}-{short2}',
-            name=f'Remain can only win if parties work together. The largest party is {long1}.',
-            remain_allicance_leader=short1,
-            remain_can_win=True,
-            alliance_helpful=True)
-
 class _NeedAlliance(ClassifyResult):
     def __new__(self, party):
         return super().__new__(self,

--- a/dontsplittheremainvote/classify.py
+++ b/dontsplittheremainvote/classify.py
@@ -59,7 +59,7 @@ class _LeaveVictory(ClassifyResult):
     def __new__(self, shortname, longname):
         return super().__new__(self,
             logo=f'leave-victory-{shortname}',
-            name=f'Largest party is {longname}. An alliance would not have helped here.',
+            name=f'Leave win: {longname}',
             remain_allicance_leader=None,
             remain_can_win=False,
             alliance_helpful=False)

--- a/dontsplittheremainvote/classify.py
+++ b/dontsplittheremainvote/classify.py
@@ -35,6 +35,9 @@ class ClassifyResult(NamedTuple):
             return None
         return get_party(self.remain_allicance_leader)
 
+    def describe(self, _result):
+        return self.name
+
     def as_json(self):
         return {
             'img': self.logo,
@@ -69,6 +72,20 @@ class _NeedAlliance(ClassifyResult):
             remain_allicance_leader=party.short,
             remain_can_win=True,
             alliance_helpful=True)
+
+    def describe(self, result):
+        remainers = [pty for pty, _share in result.remainers()]
+        big_remain, other_remain_parties = remainers[0], remainers[1:]
+        if len(other_remain_parties) == 1:
+            small_parties_text = other_remain_parties[0].name
+        else:
+            small_parties_text = '{} and {}'.format(
+                ', '.join(pty.name for pty in other_remain_parties[:-1]),
+                other_remain_parties[-1].name)
+        return 'Remain wins if {} vote for {}'.format(
+            small_parties_text,
+            big_remain.name)
+
 
 REMAIN_VICTORY_LAB = _RemainVictory('lab', 'Labour')
 REMAIN_VICTORY_LD = _RemainVictory('ld', 'Liberal Democrats')

--- a/dontsplittheremainvote/constituency_page.py
+++ b/dontsplittheremainvote/constituency_page.py
@@ -59,7 +59,8 @@ class ConstituencyPage(NamedTuple):
                 raise ValueError((self.other_sites_plus_dontsplit, self.constituency))
             return Aggregation(
                 party=party,
-                template='vote-{}.html'.format(party.short))
+                template='vote-{}.html'.format(party.short),
+                provisional=False)
         return Aggregation(
             template='contradict.html')
 

--- a/dontsplittheremainvote/other_sites.py
+++ b/dontsplittheremainvote/other_sites.py
@@ -41,6 +41,7 @@ class Aggregation(NamedTuple):
     """The advice box at the top of the page"""
     template: str
     party: Party = None
+    provisional: bool = True
 
     def as_json(self):
         return {

--- a/dontsplittheremainvote/result.py
+++ b/dontsplittheremainvote/result.py
@@ -87,6 +87,9 @@ class Result(NamedTuple):
         total_remain_vote = sum(ratio for _party, ratio in self.remainers())
         return total_remain_vote
 
+    def description(self) -> str:
+        return self.classify.describe(self)
+
     @property
     def classify(self) -> classify.ClassifyResult:
         winner = self.winner()

--- a/generated/data.json
+++ b/generated/data.json
@@ -270,7 +270,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -329,14 +329,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -376,7 +376,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -456,7 +456,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -508,7 +508,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -522,7 +522,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -691,7 +691,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -757,14 +757,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ]
@@ -809,14 +809,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -922,7 +922,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -1028,7 +1028,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -1193,7 +1193,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -1245,7 +1245,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -1318,7 +1318,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -1368,14 +1368,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -1415,7 +1415,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -1488,14 +1488,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -1658,7 +1658,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -1707,7 +1707,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -1754,7 +1754,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -1860,7 +1860,7 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           0.6000000000000001
         ],
@@ -2091,7 +2091,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -2140,7 +2140,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -2237,14 +2237,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -2298,14 +2298,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -2364,7 +2364,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -2378,7 +2378,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -2936,7 +2936,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -3071,7 +3071,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
@@ -3085,7 +3085,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -3144,14 +3144,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -3311,7 +3311,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -3351,14 +3351,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -3417,7 +3417,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -3431,7 +3431,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -3587,7 +3587,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -3684,14 +3684,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -3731,7 +3731,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -3745,7 +3745,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -3797,7 +3797,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -3856,7 +3856,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -3877,7 +3877,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -3917,7 +3917,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -4118,14 +4118,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -4198,7 +4198,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -4401,14 +4401,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -4514,7 +4514,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -4528,7 +4528,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -4580,14 +4580,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -4974,7 +4974,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -5033,7 +5033,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -5087,7 +5087,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -5146,14 +5146,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -5200,7 +5200,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -5360,14 +5360,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -5513,7 +5513,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -5694,7 +5694,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -5805,7 +5805,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -5893,14 +5893,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -6266,7 +6266,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -6379,7 +6379,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -6483,14 +6483,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.3333333333333333
         ]
@@ -6577,7 +6577,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -6631,7 +6631,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -6732,14 +6732,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -6784,7 +6784,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -6798,7 +6798,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -6900,7 +6900,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -6947,7 +6947,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -7055,7 +7055,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -7168,7 +7168,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -7232,7 +7232,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -7284,7 +7284,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -7343,7 +7343,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -7451,14 +7451,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -7512,7 +7512,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -7680,14 +7680,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.49999999999999994
         ]
@@ -7732,14 +7732,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -7843,7 +7843,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -7997,7 +7997,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -8049,7 +8049,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -8122,7 +8122,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -8186,7 +8186,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -8401,7 +8401,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ]
@@ -8453,7 +8453,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -8467,7 +8467,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -8611,7 +8611,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -8778,7 +8778,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -8875,14 +8875,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -8922,14 +8922,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -9198,7 +9198,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -9247,7 +9247,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
@@ -9372,7 +9372,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -9431,7 +9431,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -9483,14 +9483,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -9542,7 +9542,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
@@ -9556,7 +9556,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -9622,14 +9622,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -9674,14 +9674,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -9836,7 +9836,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -10193,7 +10193,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -10235,7 +10235,7 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           1.0
         ]
@@ -10287,7 +10287,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -10431,7 +10431,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -10515,7 +10515,7 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           0.4
         ]
@@ -10646,7 +10646,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -10712,7 +10712,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -10759,14 +10759,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -10825,7 +10825,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -10884,7 +10884,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -10931,7 +10931,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -11318,7 +11318,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -11332,7 +11332,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -11509,7 +11509,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -11573,14 +11573,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -11634,7 +11634,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -11693,14 +11693,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -11785,7 +11785,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -11940,14 +11940,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -12001,7 +12001,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -12015,7 +12015,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -12156,7 +12156,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -12210,7 +12210,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -12271,7 +12271,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -12292,7 +12292,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -12337,7 +12337,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -12439,7 +12439,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -12453,7 +12453,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -12498,14 +12498,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -12704,14 +12704,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -13040,7 +13040,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -13146,14 +13146,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -13252,14 +13252,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -13304,7 +13304,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -13318,7 +13318,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -13377,14 +13377,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ]
@@ -13429,14 +13429,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -13535,7 +13535,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -13684,7 +13684,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -13698,7 +13698,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -13790,14 +13790,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -14021,7 +14021,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -14085,7 +14085,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -14099,7 +14099,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -14139,7 +14139,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -14198,7 +14198,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -14309,14 +14309,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.25
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -14361,7 +14361,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -14375,7 +14375,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -14434,7 +14434,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -14488,14 +14488,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -14658,7 +14658,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -14731,7 +14731,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -14788,7 +14788,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -14842,7 +14842,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -14896,7 +14896,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -14910,7 +14910,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -14957,7 +14957,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -15011,7 +15011,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -15065,7 +15065,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -15204,7 +15204,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -15244,7 +15244,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -15362,14 +15362,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -15451,7 +15451,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -15517,7 +15517,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -15675,7 +15675,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -15972,7 +15972,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -16019,7 +16019,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -16040,7 +16040,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -16255,7 +16255,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -16314,7 +16314,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -16361,7 +16361,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -16434,7 +16434,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -16493,7 +16493,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -16507,7 +16507,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -16653,7 +16653,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -16778,7 +16778,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -16823,7 +16823,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -16953,7 +16953,7 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           1.0
         ]
@@ -17519,7 +17519,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -17578,7 +17578,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -17833,14 +17833,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -18262,7 +18262,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -18314,14 +18314,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -18361,7 +18361,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -18502,7 +18502,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -18551,7 +18551,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -18605,7 +18605,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -18619,7 +18619,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -18685,7 +18685,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -18725,14 +18725,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -18930,7 +18930,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -18944,7 +18944,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -18979,7 +18979,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -18993,7 +18993,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -19038,7 +19038,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -19144,7 +19144,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -19203,7 +19203,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -19262,7 +19262,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -19276,7 +19276,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -19323,14 +19323,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -19377,7 +19377,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -19454,14 +19454,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -19572,14 +19572,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -19680,7 +19680,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -19746,7 +19746,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -19845,7 +19845,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -19904,7 +19904,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -19970,7 +19970,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -20083,7 +20083,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -20149,14 +20149,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -20314,14 +20314,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -20363,7 +20363,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -20377,7 +20377,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -20417,7 +20417,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -20471,7 +20471,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -20537,14 +20537,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -20900,7 +20900,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -20914,7 +20914,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -20973,14 +20973,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -21022,7 +21022,7 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           1.0
         ]
@@ -21107,7 +21107,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -21128,7 +21128,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -21199,14 +21199,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -21248,14 +21248,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -21298,7 +21298,7 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           0.6000000000000001
         ],
@@ -21364,7 +21364,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -21404,7 +21404,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -21458,14 +21458,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -21517,7 +21517,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -21531,7 +21531,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -21622,7 +21622,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -21669,7 +21669,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -21716,7 +21716,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
@@ -21765,7 +21765,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -21876,7 +21876,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -21890,7 +21890,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -21937,7 +21937,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -21989,7 +21989,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -22048,14 +22048,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -22159,14 +22159,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -22213,14 +22213,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -22326,7 +22326,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -22385,7 +22385,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -22399,7 +22399,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -22451,14 +22451,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -22512,7 +22512,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -22571,7 +22571,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -22630,7 +22630,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -22689,7 +22689,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -22965,14 +22965,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -23116,14 +23116,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -23296,7 +23296,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -23548,7 +23548,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -23609,7 +23609,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -23649,7 +23649,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -23807,7 +23807,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -23821,7 +23821,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -23972,7 +23972,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -23986,7 +23986,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -24083,7 +24083,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -24097,7 +24097,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -24217,7 +24217,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -24328,7 +24328,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -24396,7 +24396,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -24445,14 +24445,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -24570,7 +24570,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -24629,14 +24629,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -24688,7 +24688,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
@@ -24702,7 +24702,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -24742,7 +24742,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -24836,7 +24836,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -24850,7 +24850,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -24892,14 +24892,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -24963,7 +24963,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -25060,7 +25060,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -25074,7 +25074,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -25131,14 +25131,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -25183,14 +25183,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -25242,7 +25242,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -25355,7 +25355,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ]
@@ -25414,14 +25414,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -25518,7 +25518,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -25532,7 +25532,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -25579,7 +25579,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -25640,7 +25640,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -25687,7 +25687,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -25785,7 +25785,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -25839,7 +25839,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -25938,7 +25938,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -25997,14 +25997,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -26063,14 +26063,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -26129,7 +26129,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -26233,14 +26233,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -26289,7 +26289,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -26558,7 +26558,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -26610,7 +26610,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
@@ -26624,7 +26624,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -26669,7 +26669,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -26728,7 +26728,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -26787,14 +26787,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -26834,7 +26834,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -26888,14 +26888,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -26980,14 +26980,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -27046,7 +27046,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -27089,14 +27089,14 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           0.2
         ],
         [
           {
             "img": "leave-victory-uup",
-            "text": "Largest party is UUP. An alliance would not have helped here."
+            "text": "Leave win: UUP"
           },
           0.2
         ],
@@ -27153,14 +27153,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.25
         ]
@@ -27200,7 +27200,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -27259,7 +27259,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -27273,7 +27273,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -27318,7 +27318,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -27339,7 +27339,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -27422,7 +27422,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -27469,7 +27469,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -27518,14 +27518,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -27565,14 +27565,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -27626,7 +27626,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -27680,7 +27680,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
@@ -27739,7 +27739,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -27845,14 +27845,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -27892,7 +27892,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -27958,7 +27958,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -28010,7 +28010,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
@@ -28024,7 +28024,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -28071,7 +28071,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -28125,14 +28125,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -28186,7 +28186,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -28245,14 +28245,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -28287,7 +28287,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
@@ -28348,7 +28348,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -28525,7 +28525,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -28539,7 +28539,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -28647,7 +28647,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -28725,7 +28725,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -28772,7 +28772,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -28786,7 +28786,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -28999,7 +28999,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -29013,7 +29013,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -29065,14 +29065,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -29176,7 +29176,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -29343,7 +29343,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -29388,7 +29388,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -29409,7 +29409,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -29520,14 +29520,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -29579,7 +29579,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -29593,7 +29593,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ]
@@ -29633,14 +29633,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -29699,7 +29699,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -29713,7 +29713,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -29748,7 +29748,7 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           1.0
         ]
@@ -29783,7 +29783,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -29953,7 +29953,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -30000,7 +30000,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -30101,7 +30101,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -30174,7 +30174,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ]
@@ -30214,7 +30214,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -30384,14 +30384,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -30431,7 +30431,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -30490,7 +30490,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -30556,14 +30556,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -30603,7 +30603,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -30645,7 +30645,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -30692,14 +30692,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.8333333333333334
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -30746,14 +30746,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.9166666666666667
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -30805,7 +30805,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -30869,14 +30869,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -30923,14 +30923,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -30979,7 +30979,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -31090,7 +31090,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.49999999999999994
         ],
@@ -31104,7 +31104,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
@@ -31203,7 +31203,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -31217,7 +31217,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -31259,7 +31259,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -31372,7 +31372,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -31412,7 +31412,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -31572,7 +31572,7 @@
         [
           {
             "img": "leave-victory-dup",
-            "text": "Largest party is DUP. An alliance would not have helped here."
+            "text": "Leave win: DUP"
           },
           0.2
         ]
@@ -31624,7 +31624,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -31742,7 +31742,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -31867,7 +31867,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -31971,7 +31971,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.25
         ],
@@ -31985,7 +31985,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -32174,7 +32174,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -32403,7 +32403,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -32476,7 +32476,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -32582,7 +32582,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -32596,7 +32596,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -32636,7 +32636,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -32759,7 +32759,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -32773,7 +32773,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ]
@@ -32823,7 +32823,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -32882,7 +32882,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.41666666666666663
         ],
@@ -32948,14 +32948,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.16666666666666666
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ],
@@ -33153,7 +33153,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -33331,14 +33331,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -33427,7 +33427,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -33585,7 +33585,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -33599,7 +33599,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -33719,7 +33719,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ]
@@ -33771,7 +33771,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -33813,7 +33813,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -33983,14 +33983,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -34044,7 +34044,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -34098,7 +34098,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -34152,7 +34152,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -34218,7 +34218,7 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -34381,7 +34381,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.16666666666666666
         ],
@@ -34447,14 +34447,14 @@
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.08333333333333333
         ]
@@ -34546,7 +34546,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.5833333333333333
         ],
@@ -34666,7 +34666,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
@@ -34718,7 +34718,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.6666666666666666
         ],
@@ -34777,14 +34777,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.75
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -34895,14 +34895,14 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],
         [
           {
             "img": "leave-victory-ukip",
-            "text": "Largest party is UKIP / Brexit. An alliance would not have helped here."
+            "text": "Leave win: UKIP / Brexit"
           },
           0.08333333333333333
         ],
@@ -35074,7 +35074,7 @@
         [
           {
             "img": "leave-victory-con",
-            "text": "Largest party is Conservative. An alliance would not have helped here."
+            "text": "Leave win: Conservative"
           },
           0.3333333333333333
         ],

--- a/templates/agg/base-vote.html
+++ b/templates/agg/base-vote.html
@@ -3,5 +3,10 @@
 Vote {% block party %}a remain party{% endblock %} for the best chance of a remain victory
 {% endblock %}
 {% block adviceblock %}
-  <li>Vote for a remain party</li>
+<p>
+Most tactical voting websites recommend voting for {% block party2 %}a remain party{% endblock %}.
+</p>
+<p>
+{% block partypromise %}{% endblock %}
+</p>
 {% endblock %}

--- a/templates/agg/base.html
+++ b/templates/agg/base.html
@@ -1,9 +1,6 @@
 <div class="section advice">
   <img class="mainlogo" src="{{static}}/logo/{% block image %}outcome/difficult-alliance.png{% endblock %}" />
   <h2>{% block advicetitle %}{{aggregation.title}}{% endblock %}</h2>
-  <ul class="checklist">
-    <li><a href="https://www.gov.uk/register-to-vote">Register to Vote</a> today</li>
-    {% block adviceblock %}{% endblock %}
-  </ul>
+  {% block adviceblock %}{% endblock %}
   <div class="clear"></div>
 </div>

--- a/templates/agg/contradict.html
+++ b/templates/agg/contradict.html
@@ -1,7 +1,17 @@
 {% extends "agg/base.html" %}
 {% block advicetitle %}Remain can win if we back one party{% endblock %}
 {% block adviceblock %}
-  <li>Remain parties need to work together to maximise the chances of winning.</li>
-  <li>It is not certain which remain party to back: in the recommendations below, more than one remain party could win.</li>
-  <li>Use your local knowledge: keep an eye on local newspapers, <a href="https://electionleaflets.org/">election leaflets</a>, and social media.</li>
+<p>
+Tactical voting websites disagree on which party to vote for.
+</p>
+<p>
+Some websites base their suggestions on the 2017 General Election, while others use recent opinion polls.
+</p>
+<p>
+Will Labour gain voters during a successful election campaign, like in 2017?
+Or will the Liberal Democrats sustain the momentum gained during the European Parliament elections?
+</p>
+<p>
+Use your local knowledge: keep an eye on local newspapers, <a href="https://electionleaflets.org/">election leaflets</a>, and social media.
+</p>
 {% endblock %}

--- a/templates/agg/pending.html
+++ b/templates/agg/pending.html
@@ -2,6 +2,7 @@
 {% block image %}tick/clock.png{% endblock %}
 {% block advicetitle %}Waiting for recommendations{% endblock %}
 {% block adviceblock %}
-  <li>Remain parties need to work together to maximise the chances of winning.</li>
-  <li>There are not enough recommendations to advise on who to vote for. Check later when more recommendations have been released.</li>
+<p>
+There are not enough recommendations to advise on who to vote for. Check later when more recommendations have been released.
+</p>
 {% endblock %}

--- a/templates/agg/vote-alliance.html
+++ b/templates/agg/vote-alliance.html
@@ -1,7 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/alliance.png{% endblock %}
 {% block party %}Alliance{% endblock %}
-{% block adviceblock %}
-  <li>Vote for <em class="alliance">Alliance</em>. Alliance are offering <a href="https://www.allianceparty.org/brexit">a new referendum with an option to remain</a>.</li>
-  <li>No other remain party can win here. Splitting the vote could cause us to lose to a party supporting a no deal brexit.</li>
+{% block party2 %}Alliance{% endblock %}
+{% block partypromise %}
+Alliance are offering <a href="https://www.allianceparty.org/brexit">a new referendum with an option to remain</a>.
 {% endblock %}

--- a/templates/agg/vote-green.html
+++ b/templates/agg/vote-green.html
@@ -1,7 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/green.png{% endblock %}
 {% block party %}Green{% endblock %}
-{% block adviceblock %}
-  <li>Vote for <em class="lab">Green</em>. The Green Party are offering <a href="https://www.greenparty.org.uk/europe-priorities.html">a new referendum</a>.</li>
-  <li>No other remain party can win here. Splitting the vote could cause us to lose to a party supporting a no deal brexit.</li>
+{% block party2 %}Green{% endblock %}
+{% block partypromise %}
+The Green Party are offering <a href="https://www.greenparty.org.uk/europe-priorities.html">a new referendum</a>.
 {% endblock %}

--- a/templates/agg/vote-ind-wright.html
+++ b/templates/agg/vote-ind-wright.html
@@ -1,7 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/ind-wright.png{% endblock %}
 {% block party %}Claire Wright{% endblock %}
-{% block adviceblock %}
-  <li>Vote for <em>Claire Wright</em>. She is offering <a href="https://claire-wright.org/about/faq/">a new referendum</a>.</li>
-  <li>No other remain party can win here. Splitting the vote could cause us to lose to a party supporting a no deal brexit.</li>
+{% block party2 %}Claire Wright{% endblock %}
+{% block partypromise %}
+She is offering <a href="https://claire-wright.org/about/faq/">a new referendum</a>.
 {% endblock %}

--- a/templates/agg/vote-lab.html
+++ b/templates/agg/vote-lab.html
@@ -1,7 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/lab.png{% endblock %}
 {% block party %}Labour{% endblock %}
-{% block adviceblock %}
-  <li>Vote for <em class="lab">Labour</em>. Labour are offering <a href="https://www.bbc.co.uk/news/uk-politics-45640548">a new referendum with an option to remain</a>.</li>
-  <li>No other remain party can win here. Splitting the vote could cause us to lose to a party supporting a no deal brexit.</li>
+{% block party2 %}Labour{% endblock %}
+{% block partypromise %}
+Labour are offering <a href="https://www.bbc.co.uk/news/uk-politics-45640548">a new referendum with an option to remain</a>.
 {% endblock %}

--- a/templates/agg/vote-ld.html
+++ b/templates/agg/vote-ld.html
@@ -1,7 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/ld.png{% endblock %}
 {% block party %}Liberal Democrat{% endblock %}
-{% block adviceblock %}
-  <li>Vote for the <em class="ld">Liberal Democrats</em>. The Lib Dems have promised to <a href="https://www.theguardian.com/politics/2019/sep/15/lib-dems-pledge-to-revoke-brexit-without-referendum">revoke Article 50</a>.</li>
-  <li>No other remain party can win here. Splitting the vote could cause us to lose to a party supporting a no deal brexit.</li>
+{% block party2 %}Liberal Democrat{% endblock %}
+{% block partypromise %}
+The Lib Dems have promised to <a href="https://www.theguardian.com/politics/2019/sep/15/lib-dems-pledge-to-revoke-brexit-without-referendum">revoke Article 50</a>.
 {% endblock %}

--- a/templates/agg/vote-plaid.html
+++ b/templates/agg/vote-plaid.html
@@ -1,7 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/plaid.png{% endblock %}
 {% block party %}Plaid Cymru{% endblock %}
-{% block adviceblock %}
-  <li>Vote for <em class="plaid">Plaid Cymru</em>. Plaid Cymru are offering <a href="https://www.partyof.wales/plaid_cymru_conference_in_huge_support_for_commitment_to_people_s_vote">a new referendum with an option to remain</a>.</li>
-  <li>No other remain party can win here. Splitting the vote could cause us to lose to a party supporting a no deal brexit.</li>
+{% block party2 %}Plaid Cymru{% endblock %}
+{% block partypromise %}
+Plaid Cymru are offering <a href="https://www.partyof.wales/plaid_cymru_conference_in_huge_support_for_commitment_to_people_s_vote">a new referendum with an option to remain</a>.
 {% endblock %}

--- a/templates/agg/vote-sdlp.html
+++ b/templates/agg/vote-sdlp.html
@@ -1,6 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/sdlp.png{% endblock %}
 {% block party %}SDLP{% endblock %}
-{% block adviceblock %}
-  <li>Vote for <em class="sdlp">SDLP</em>. The SDLP <a href="https://www.sdlp.ie/issues/manifesto-2019/">want to remain outright</a>, but failing that are pushing for a second referendum.</li>
+{% block party2 %}SDLP{% endblock %}
+{% block partypromise %}
+The SDLP <a href="https://www.sdlp.ie/issues/manifesto-2019/">want to remain outright</a>, but failing that are pushing for a second referendum.
 {% endblock %}

--- a/templates/agg/vote-sf.html
+++ b/templates/agg/vote-sf.html
@@ -1,7 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/sf.png{% endblock %}
 {% block party %}Sinn Fein{% endblock %}
-{% block adviceblock %}
-  <li>Vote for <em class="alliance">Sinn Fein</em>.</li>
-  <li>Sinn Fein do not take their seats at parliament, but voting for them may stop a pro-leave candidate winning.</li>
+{% block party2 %}Sinn Fein{% endblock %}
+{% block partypromise %}
+Sinn Fein do not take their seats at parliament, but voting for them may stop a pro-leave candidate winning.
 {% endblock %}

--- a/templates/agg/vote-snp.html
+++ b/templates/agg/vote-snp.html
@@ -1,7 +1,7 @@
 {% extends "agg/base-vote.html" %}
 {% block image %}tick/snp.png{% endblock %}
 {% block party %}SNP{% endblock %}
-{% block adviceblock %}
-  <li>Vote for <em class="snp">SNP</em>. The SNP are offering <a href="https://www.snp.org/policies/what-is-the-snp-plan-for-brexit/">a new referendum with an option to remain</a>.</li>
-  <li>No other remain party can win here. Splitting the vote could cause us to lose to a party supporting a no deal brexit.</li>
+{% block party2 %}SNP{% endblock %}
+{% block partypromise %}
+The SNP are offering <a href="https://www.snp.org/policies/what-is-the-snp-plan-for-brexit/">a new referendum with an option to remain</a>.
 {% endblock %}

--- a/templates/constituency.html
+++ b/templates/constituency.html
@@ -33,10 +33,13 @@
   <img class="tick" src="{{static}}/logo/tick/other.png" alt="Other tick" />
   <strong>Waiting for recommendations</strong> from <em>People's Vote</em>, <em>Remain United</em>, <em>Unite to Remain</em> and others.
 </div>
+
+{% if aggregation.provisional %}
 <div class="othersite">
   <img class="tick" src="{{static}}/logo/tick/clock.png" alt="Clock" />
   <strong>Recommendations can change</strong>. Please check the site occasionally as the election campaign progresses.
 </div>
+{% endif %}
 
 <div class="widebutton"><a href="https://www.gov.uk/register-to-vote">gov.uk/register-to-vote</a></div>
 

--- a/templates/constituency.html
+++ b/templates/constituency.html
@@ -66,8 +66,8 @@ No candidates announced yet.
 {% include 'analysis/' + analysis.template %}
 </div>
 
-<div id="more-scenarios-link" style="padding: 0.2em;"><a href="#" onclick="document.getElementById('more-scenarios').style=display=''; document.getElementById('more-scenarios-link').style.display='none'; return false" style="width: 50%; display: inline-block;">Why we think this &mdash; election results adjusted for polling</a></div>
-<div id="more-scenarios" style="display: none;">
+<details>
+  <summary>Why we think this &mdash; election results adjusted for polling</summary>
 
 <h3>Which outcomes are possible?</h3>
 <div class="section outcome-summary">
@@ -87,7 +87,7 @@ No candidates announced yet.
 {% endfor %}
 </div>
 
-</div>{# end hidden section #}
+</details>{# end hidden section #}
 
 <h2>Social</h2>
 

--- a/templates/scenario.html
+++ b/templates/scenario.html
@@ -2,7 +2,7 @@
     <h4><a href="/datasets.html#{{dataset.code}}">{{dataset.title}}</a></h4>
     <img class="logo" src="{{static}}/logo/{{result.classify.logo}}.png" />
     <div class="beside-logo">
-      <div>{{result.classify.name}}</div>
+      <div>{{result.description()}}</div>
       <div class="barchart">{% for party, vote in result.remainers() %}<span class="bar" title="{{party.name}}" style="background: {{party.color}}; width: {{(100 * vote)|int}}%">&nbsp;</span>{% endfor %}</div>
       <div class="barchart">{% for party, vote in result.leavers() %}<span class="bar" title="{{party.name}}" style="background: {{party.color}}; width: {{(100 * vote)|int}}%">&nbsp;</span>{% endfor %}</div>
     </div>

--- a/templates/style.css
+++ b/templates/style.css
@@ -180,3 +180,7 @@ div.widebutton a {
 div.indent {
   margin-left: 1em;
 }
+
+summary {
+  cursor: pointer;
+}


### PR DESCRIPTION
A number of re-wording changes.

These changes are currently shown on https://dontsplittheremainvote.dbatley.com/

Change the summary box from a bullet point list to a 2-sentence description:

- changes "only X can win here" to "Most tactical voting websites recommend voting for X" because that's how we calculate it
- I wrote too much to describe why TV site can disagree ([example](https://dontsplittheremainvote.dbatley.com/constituency/colchester.html))

In election results (and analysis)

- Cahnge "Remain can win if we work together. The largest party is Labour." with "Remain wins if Liberal Democrat vote for Labour" which is shorter and explains what's going on