### PR TITLE
Add recommended meta tags

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" prefix="og:http://ogp.me/ns">
+  <meta charset="UTF-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>{% block title %}{% endblock %} - Don't Split the Remain Vote!</title>
   <meta property="og:title" content="{% block title2 %}{% endblock %} - Don't Split the Remain Vote!" />
   <meta property="twitter:title" content="{% block title3 %}{% endblock %} - Don't Split the Remain Vote!" />


### PR DESCRIPTION
REF: https://codeguide.co/#html-ie-compatibility-mode

> Internet Explorer supports the use of a document compatibility <meta> tag to specify what version of IE the page should be rendered as. Unless circumstances require otherwise, it's most useful to instruct IE to use the latest supported mode with edge mode.

REF: https://codeguide.co/#html-encoding

> Quickly and easily ensure proper rendering of your content by declaring an explicit character encoding. When doing so, you may avoid using character entities in your HTML, provided their encoding matches that of the document (generally UTF-8).